### PR TITLE
correct java location in docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,4 +11,4 @@ export PKI_KEYSTORE
 export PKI_STOREPASS
 export PKI_KEYPASS
 
-exec /usr/bin/java -jar /usr/share/tenant-example/tenant-example.jar
+exec /usr/local/openjdk-8/bin/java -jar /usr/share/tenant-example/tenant-example.jar


### PR DESCRIPTION
location of the java binary in `openjdk:8` is `/usr/local/openjdk-8/bin/java`